### PR TITLE
Merge beta into master for 2021.07.28.02

### DIFF
--- a/WME-BDP-Check.js
+++ b/WME-BDP-Check.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name        WME BDP Check (beta)
 // @namespace   https://greasyfork.org/users/166843
-// @version     2021.07.28.01
+// @version     2021.07.28.02
 // @description Check for possible BDP routes between two selected segments.
 // @author      dBsooner
 // @include     /^https:\/\/(www|beta)\.waze\.com\/(?!user\/)(.{2,6}\/)?editor\/?.*$/


### PR DESCRIPTION
### 2021.07.28.01
<b>NEW:</b> Check detour selection for unroutable segment types.
<b>CHANGE:</b> WME map object references.
<b>CHANGE:</b> Routes must be selected by clicking first bracketing segment first and second bracketing segment last.
<b>BUGFIX:</b> Zoom levels 1-3 do not contain LS or PS segments.
<b>BUGFIX:</b> Better handling of multiple segments in detour route connected to same final node.